### PR TITLE
Add Google analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Here is a template for new release sections
 ## [Unreleased]
 
 ### Added
+- Added GA (#70)
 - Linting with prettier JS (#67, #68, #69)
 - Template for `request-event-evaluation` (label "Event Prediction") (#62)
 - Template for sidebar (#62)

--- a/src/server/templates/base.html
+++ b/src/server/templates/base.html
@@ -28,26 +28,20 @@
     <!-- Custom styles for this template -->
     <link href="../static/css/main.css" rel="stylesheet" />
 
+    <!-- Global site tag (gtag.js) - Google Analytics -->
     <script
-      type="text/javascript"
-      src="https://cdn.bokeh.org/bokeh/release/bokeh-2.0.0.min.js"
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=UA-160643838-1"
     ></script>
-    <script
-      type="text/javascript"
-      src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.0.0.min.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.0.0.min.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="https://cdn.bokeh.org/bokeh/release/bokeh-gl-2.0.0.min.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="https://cdn.bokeh.org/bokeh/release/bokeh-api-2.0.0.min.js"
-    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "UA-160643838-1");
+    </script>
 
     {% block additional_js_pre %} {% endblock %}
 
@@ -167,6 +161,7 @@
       href="https://fonts.googleapis.com/css?family=DM+Sans&display=swap"
       rel="stylesheet"
     />
+
     {% block additional_js %} {% endblock %}
   </body>
 </html>

--- a/src/server/templates/base.html
+++ b/src/server/templates/base.html
@@ -161,6 +161,10 @@
       href="https://fonts.googleapis.com/css?family=DM+Sans&display=swap"
       rel="stylesheet"
     />
+    <script
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/cookie-bar/cookiebar-latest.min.js?tracking=1&top=1"
+    ></script>
 
     {% block additional_js %} {% endblock %}
   </body>


### PR DESCRIPTION
I used https://cookie-bar.eu/?tracking=1#installation . It's on the top because it didn't display correctly at the bottom, as it's kind of broken now... If you could later fix it and place it at the bottom, it would be great. 

Also, is it a problem that it's always on, e.g. during development and staging?