### PR TITLE
Remove my name from collaborator

### DIFF
--- a/src/server/templates/about.html
+++ b/src/server/templates/about.html
@@ -44,7 +44,6 @@ active_page = 'about' -%} {% block additional_js_pre %}
         <li>David Johnston (PhD, Australian National University)</li>
         <li>Daniel Hnyk (Engineering manager, GlobalWebIndex)</li>
         <li>Peter Hrosso (Founder &amp; tech lead, Aird Works)</li>
-        <li>Pierre Francois Duc (Researcher, Reiner Lemoine Institute)</li>
         <li>Ondřej Švec (Software engineer, Google)</li>
         <li>Jan Pipek (Data scientists, DT One)</li>
         <li>Jan Losert (Product designer, Webflow)</li>


### PR DESCRIPTION
My current contributions to this project are on the website and are already
accounted for by my github commits. I haven't participated in the
elaboration of the model and/or data pipeline and therefore would not like
to have my name listed proheminently there.