### PR TITLE
Fix styling on lines more details button

### DIFF
--- a/src/server/static/css/main.css
+++ b/src/server/static/css/main.css
@@ -371,6 +371,8 @@ label.btn-secondary > input {
   border-width: 0px;
   min-width: 132px;
   margin-bottom: 12px;
+  padding: 0;
+  text-align: right
 }
 
 .less-visible7 {
@@ -415,7 +417,11 @@ strong {
   padding-top: 10px;
 }
 
-.mitigation-strenght > div > .btn-secondary {
+.mitigation-strength {
+  margin-left: auto;
+}
+
+.mitigation-strength > div > .btn-secondary {
   min-width: 76px;
 }
 
@@ -427,7 +433,7 @@ strong {
     margin-top: 20px;
     margin-right: 0px;
   }
-  .mitigation-strenght {
+  .mitigation-strength {
     margin-top: 8px;
   }
 }
@@ -491,6 +497,10 @@ strong {
   .main-wrapper {
     padding: 15px 15px;
   }
+  .detail-button {
+    text-align: left
+  }
+
 }
 
 .fill-available-width {

--- a/src/server/templates/lines.html
+++ b/src/server/templates/lines.html
@@ -46,34 +46,31 @@
         Strong
       </label>
     </div>
+    <div class="col-sm-auto col-xm-12 mitigation-strength">
+      <button id="showMitigation" onclick="showExplanation('showMitigation','hideMitigation','explanationMitigation')"
+        class="detail-button less-visible7">
+        More detail <svg class="bi bi-chevron-down" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg">
+          <path fill-rule="evenodd"
+            d="M1.646 4.646a.5.5 0 01.708 0L8 10.293l5.646-5.647a.5.5 0 01.708.708l-6 6a.5.5 0 01-.708 0l-6-6a.5.5 0 010-.708z"
+            clip-rule="evenodd" />
+        </svg>
+      </button>
+      <button id="hideMitigation" onclick="hideExplanation('showMitigation','hideMitigation','explanationMitigation')"
+        class="detail-button less-visible7" style="display: none;">
+        Less detail <svg class="bi bi-chevron-up" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg">
+          <path fill-rule="evenodd"
+            d="M7.646 4.646a.5.5 0 01.708 0l6 6a.5.5 0 01-.708.708L8 5.707l-5.646 5.647a.5.5 0 01-.708-.708l6-6z"
+            clip-rule="evenodd" />
+        </svg>
+      </button>
+    </div>
+
   </div>
 </div>
 
 <!-- Toggleable explanation -->
-<p><i>Choose the aggregate effect on COVID-19 transmission rate, of all mitigation measures implemented globally (not
-    just in <span class="selected-region"></span>).</i>
-</p>
-<div class="row mitigation-strenght">
-  <button id="showMitigation" onclick="showExplanation('showMitigation','hideMitigation','explanationMitigation')"
-    class="detail-button less-visible7">
-    More detail <svg class="bi bi-chevron-down" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
-      <path fill-rule="evenodd"
-        d="M1.646 4.646a.5.5 0 01.708 0L8 10.293l5.646-5.647a.5.5 0 01.708.708l-6 6a.5.5 0 01-.708 0l-6-6a.5.5 0 010-.708z"
-        clip-rule="evenodd" />
-    </svg>
-  </button>
-  <button id="hideMitigation" onclick="hideExplanation('showMitigation','hideMitigation','explanationMitigation')"
-    class="detail-button less-visible7" style="display: none;">
-    Less detail <svg class="bi bi-chevron-up" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
-      <path fill-rule="evenodd"
-        d="M7.646 4.646a.5.5 0 01.708 0l6 6a.5.5 0 01-.708.708L8 5.707l-5.646 5.647a.5.5 0 01-.708-.708l6-6z"
-        clip-rule="evenodd" />
-    </svg>
-  </button>
-</div>
-
 <div id="explanationMitigation" class="row less-visible8" style="display: none;">
   <div class="col-12">
     We're modelling containment measures via their impact on effective transmission rate, since the same mitigation
@@ -93,6 +90,11 @@
       our &quot;Strong&quot; setting.</p>
   </div>
 </div>
+
+<p><i>Choose the aggregate effect on COVID-19 transmission rate, of all mitigation measures implemented globally (not
+    just in <span class="selected-region"></span>).</i>
+</p>
+
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>


### PR DESCRIPTION
This PR moves the More Details button to be right align on the desktop to save space (https://epidemicforecasting.slack.com/archives/CV0GGP151/p1585189601006600)

## Before
Desktop collapsed
<img width="981" alt="Screen Shot 2020-03-25 at 7 55 10 PM" src="https://user-images.githubusercontent.com/8121736/77605677-c4132d00-6ed2-11ea-8495-c6b00cb67982.png">
Mobile collapsed
<img width="367" alt="Screen Shot 2020-03-25 at 7 55 40 PM" src="https://user-images.githubusercontent.com/8121736/77605674-c4132d00-6ed2-11ea-9c92-7354d0283976.png">

## After
Desktop collapsed
<img width="996" alt="Screen Shot 2020-03-25 at 7 53 43 PM" src="https://user-images.githubusercontent.com/8121736/77605547-77c7ed00-6ed2-11ea-940a-ec31f30f56bf.png">
Desktop expanded
<img width="1076" alt="Screen Shot 2020-03-25 at 7 53 47 PM" src="https://user-images.githubusercontent.com/8121736/77605551-7991b080-6ed2-11ea-8387-e7a17374b427.png">
Mobile collapsed
<img width="383" alt="Screen Shot 2020-03-25 at 7 54 00 PM" src="https://user-images.githubusercontent.com/8121736/77605555-7ac2dd80-6ed2-11ea-9dc1-29e0ffedc6ab.png">
Mobile expanded
<img width="373" alt="Screen Shot 2020-03-25 at 7 54 11 PM" src="https://user-images.githubusercontent.com/8121736/77605556-7b5b7400-6ed2-11ea-96a4-e2e786874f8a.png">
