### PR TITLE
Fix alert banner styling

### DIFF
--- a/src/server/static/css/main.css
+++ b/src/server/static/css/main.css
@@ -425,6 +425,10 @@ strong {
   min-width: 76px;
 }
 
+.alert-warning > p {
+  margin-bottom: 0px;
+}
+
 @media only screen and (max-width: 991px) {
   .title {
     text-align: center;
@@ -500,7 +504,10 @@ strong {
   .detail-button {
     text-align: left
   }
-
+  .alert-warning > p {
+    margin-bottom: 0px;
+    font-size: 0.75rem
+  }
 }
 
 .fill-available-width {

--- a/src/server/templates/model.html
+++ b/src/server/templates/model.html
@@ -35,22 +35,23 @@
 </style>
 {% endblock %} {% block content %}
 
-<!-- Pro bono consulting alert-->
-<div class="alert alert-warning alert-dismissible fade show" role="alert">
-  <p class="text-center">
-    We're offering pro bono consulting services and custom forecasts for decision-makers. Please reach out <a
-      href="http://epidemicforecasting.org/request-calculation" class="alert-link">here</a>. </p>
-  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-    <span aria-hidden="true">&times;</span>
-  </button>
-</div>
+
 
 <!-- Main model graph -->
 <div class="main-wrapper">
   <div class="row">
-    <div class="col"></div>
-    <div class="col-xs-11 col-sm-10 col-md-9 col-lg-8 col-xl-6">
-
+    <div class="col">
+    </div>
+    <div class="col-xs-12 col-sm-10 col-md-9 col-lg-8 col-xl-6">
+      <!-- Pro bono consulting alert-->
+      <div class="alert alert-warning alert-dismissible fade show" role="alert">
+        <p class="text-center">
+          We're offering pro bono consulting services and custom forecasts for decision-makers. Please reach out <a
+            href="http://epidemicforecasting.org/request-calculation" class="alert-link">here</a>. </p>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
       {% include "lines.html" %}
       <p>
         Under this scenario, with high confidence (90%) we estimate:


### PR DESCRIPTION
This PR fixes styling for the alert banner on the Model page

## Desktop
Before:
![Screen Shot 2020-03-29 at 2 48 48 PM](https://user-images.githubusercontent.com/8121736/77861949-156e3580-71cd-11ea-8149-08af19c97b53.png)
After: 
![Screen Shot 2020-03-29 at 2 48 39 PM](https://user-images.githubusercontent.com/8121736/77861948-14d59f00-71cd-11ea-8d60-306abb2dccb1.png)

## Mobile
Before:
![Screen Shot 2020-03-29 at 2 49 05 PM](https://user-images.githubusercontent.com/8121736/77861950-169f6280-71cd-11ea-934a-5565a7c1a34c.png)
After:
![Screen Shot 2020-03-29 at 2 50 49 PM](https://user-images.githubusercontent.com/8121736/77861951-169f6280-71cd-11ea-9c22-c06cfad22d2c.png)
