### PR TITLE
Combine download data

### DIFF
--- a/src/server/templates/about.html
+++ b/src/server/templates/about.html
@@ -80,21 +80,6 @@
           1, 132 (2010).
         </li>
       </ul>
-      <h5 class="mt-3">Active datasets</h5>
-      <ul>
-        <li><a href="https://storage.googleapis.com/static-covid/static/simulation-defs-main.zip">GLEAM simulation
-            definitions with infection estimates</a></li>
-        <li><a href="https://storage.googleapis.com/static-covid/static/data-main-v3.json">Results data</a>
-          (JSON, see the <a href="https://github.com/epidemics/covid/blob/master/docs/data-specification.md">specification</a>)</li>
-        <li><a href="https://www.notion.so/977d5e5be0434bf996704ec361ad621d?v=fe54f89ca9e04ac799af42b39e1efc4b">Country
-            containment measures</a></li>
-        <li><a href="https://storage.googleapis.com/static-covid/static/countries-spread.csv">Country spreads map data</a></li>
-      </ul>
-
-      <h5 class="mt-3">License of the output data </h5>
-        The original scenario's output data are licensed under CC0 <a href="http://creativecommons.org/publicdomain/zero/1.0/">
-          <img src="https://licensebuttons.net/p/zero/1.0/88x31.png" alt="CC0" style="'border-style': 'none'" >
-        </a>
       </div>
   </div>
 

--- a/src/server/templates/containment.html
+++ b/src/server/templates/containment.html
@@ -43,23 +43,25 @@
             <p>As of March 23rd, with about 1000 entries, we are ~30% through, and by March 27 we hope to have a stable
                 release with consistent labels and 3000 entries for the most highly prioritised nations (based on
                 population and current infection rate).</p>
-
             </br>
             <h5>Download the data</h5>
-            <p>Data is available as a <code>&lt;.csv&gt;</code> file <a
-                    href="https://storage.googleapis.com/static-covid/Containment%20measures/COVID-19%20containment%20measures.zip">here</a>.
-            </p>
-            <p>(Last updated March 23rd. To get the most recent data, make a copy of the <a
-                    href="https://www.notion.so/977d5e5be0434bf996704ec361ad621d?v=fe54f89ca9e04ac799af42b39e1efc4b">Notion
-                    database</a>, and then click &quot;Export&quot;.)</p>
-
-            </br>
-            <h5>Explore the data</h5>
-            <p>You can get an overview of the data, and sort it by country, by response measure, or by a calendar view,
-                in the <a
-                    href="https://www.notion.so/977d5e5be0434bf996704ec361ad621d?v=fe54f89ca9e04ac799af42b39e1efc4b">Notion
-                    database</a>.</p>
-
+            <i>GLEAMviz Dataset</i>
+            <ul>
+              <li><a href="https://storage.googleapis.com/static-covid/static/simulation-defs-main.zip">GLEAM simulation
+                  definitions with infection estimates</a></li>
+              <li><a href="https://storage.googleapis.com/static-covid/static/data-main-v3.json">Results data</a>
+                (JSON, see the <a href="https://github.com/epidemics/covid/blob/master/docs/data-specification.md">specification</a>)</li>
+            </ul>
+            <i>Other Files</i>
+            <ul>
+              <li><a href="https://www.notion.so/977d5e5be0434bf996704ec361ad621d?v=fe54f89ca9e04ac799af42b39e1efc4b">Country
+                  containment measures</a></li>
+              <li><a href="https://storage.googleapis.com/static-covid/static/countries-spread.csv">Country spreads map data</a></li>
+              <li><a href="https://storage.googleapis.com/static-covid/Containment%20measures/COVID-19%20containment%20measures.zip">Containment Measures (CSV)</a></li> 
+              <li><a href="https://www.notion.so/977d5e5be0434bf996704ec361ad621d?v=fe54f89ca9e04ac799af42b39e1efc4b">Containment Measures (Notion Database Export)</a></li> 
+            </ul>
+            <h5>Dataset LICENSE</h5>
+            <p>These datasets are licensed under the MIT license.</p>
             </br>
             <h5>Modelling the effectiveness of containment measures</h5>
             <p>We are currently pursuing a machine learning project to model the effectiveness of various measures to
@@ -102,9 +104,6 @@
             </form>
 
             </br>
-
-            <h5>Usage</h5>
-            The dataset is licensed under the MIT license.
 
         </div>
     </div>


### PR DESCRIPTION
This PR combines the dataset downloads on the About and Mitigation pages into a single place on the Mitigation page. It also places all of the datasets under a single MIT license.

## Before
About page
![Screen Shot 2020-03-29 at 4 10 44 PM](https://user-images.githubusercontent.com/8121736/77863573-443dd900-71d8-11ea-91cb-7493d1dca8c7.png)
Mitigation page
![Screen Shot 2020-03-29 at 4 10 37 PM](https://user-images.githubusercontent.com/8121736/77863574-44d66f80-71d8-11ea-8dd2-3870881ce0fc.png)

## After
Mitigation page
![Screen Shot 2020-03-29 at 4 14 05 PM](https://user-images.githubusercontent.com/8121736/77863586-54ee4f00-71d8-11ea-9e34-374ad4964bdc.png)
