### PR TITLE
WIP: Improve 'Mitigation strength' in frontend

### DIFF
--- a/src/server/templates/lines.html
+++ b/src/server/templates/lines.html
@@ -72,9 +72,9 @@
   </div>
 </div>
 <hr />
-<h5>Global mitigation strength</h5>
+<h5>National and global transmission reduction</h5>
 <div class="btn-group-toggle" id="mitigation" data-toggle="buttons">
-  <div class="row mitigation-strenght">
+  <div class="row mitigation-strengt">
     <div class="col-sm-auto col-xm-12">
       <label class="btn btn-secondary active beta-0">
         <input type="radio" name="mitigation" id="mitigation-none" autocomplete="off" value="none" />
@@ -84,19 +84,19 @@
     <div class="col-sm-auto col-xm-12">
       <label class="btn btn-secondary active beta-05">
         <input type="radio" name="mitigation" id="mitigation-weak" autocomplete="off"  value="weak"  />
-        Weak
+        -20%
       </label>
     </div>
     <div class="col-sm-auto col-xm-12">
       <label class="btn btn-secondary active beta-04">
         <input type="radio" name="mitigation" id="mitigation-moderate" autocomplete="off"  value="moderate" />
-        Moderate
+        -50%
       </label>
     </div>
     <div class="col-sm-auto col-xm-12">
       <label class="btn btn-secondary active beta-03">
         <input type="radio" name="mitigation" id="mitigation-strong" autocomplete="off"  value="strong"/>
-        Strong
+        -80%
       </label>
     </div>
     <div class="col-sm-auto col-xm-12 mitigation-strength">


### PR DESCRIPTION
This PR is for addressing #268, #269, and #270:
1. turn weak/moderate/strong into 20%/50%/80%. I think this will importantly reduce ambiguity (
2. don't make the 'details' optionally pop in/out but leave them out for good
3. turn 'global mitigation strength' into 'national and global mitigation strength'

I have the following suggestion:
![image](https://user-images.githubusercontent.com/242143/78034952-bb09dc00-7368-11ea-9e7b-4026179bb31f.png)

The copy would still have to be modified.