### PR TITLE
Make chart more responsive to small screens

### DIFF
--- a/src/server/static/css/main.css
+++ b/src/server/static/css/main.css
@@ -580,21 +580,22 @@ div.tooltip {
   opacity: 0.2;
 }
 
-.svg-container {
-  display: inline-block;
-  position: relative;
+#my_dataviz {
   width: 100%;
+  height: 0;
   padding-bottom: 100%;
   vertical-align: top;
   overflow: hidden;
 }
 
-.svg-content {
-  display: inline-block;
-  position: absolute;
-  top: 0;
-  left: 0;
+.js-plotly-plot .plotly .svg-container {
+  position: relative;
 }
+
+.js-plotly-plot .plotly .main-svg:first-child {
+  position: relative;
+}
+
 /*
 @media only screen and (max-width: 767px) {
   .legend {

--- a/src/server/static/js/lines.js
+++ b/src/server/static/js/lines.js
@@ -8,6 +8,11 @@ const MITIGATION_PARAM = "mitigation";
 const CHANNEL_PARAM = "channel";
 const REGION_FALLBACK = "united kingdom";
 
+// Set starting chart size based on screen size
+const CHART_HEIGHT_RATIO = Math.max(0.5, Math.min(1, window.innerHeight / window.innerWidth));
+const CHART_WIDTH = Math.max(500, Math.min(1000, window.innerWidth * 0.6));
+const CHART_HEIGHT = Math.round(CHART_WIDTH * CHART_HEIGHT_RATIO);
+
 function getUrlParams() {
   let urlString = window.location.href;
   let url = new URL(urlString);
@@ -159,8 +164,8 @@ var plotyGraph = document.getElementById("my_dataviz");
 
 // graph layout
 var layout = {
-  height: 600,
-  width: 600,
+  width: CHART_WIDTH,
+  height: CHART_HEIGHT,
   //margin: { t: 0 },
   paper_bgcolor: "#222028",
   plot_bgcolor: "#222028",
@@ -231,21 +236,22 @@ var plotlyConfig = {
   scrollZoom: false
 };
 
-function adjustPlotlyChart() {
+function makePlotlyReactive() {
+  d3.select("#my_dataviz")
+    .style('padding-bottom', `${CHART_HEIGHT / CHART_WIDTH * 100}%`);
   d3.select(".js-plotly-plot .plotly .svg-container")
     .attr("style", null);
   d3.selectAll(".js-plotly-plot .plotly .main-svg")
     .attr("height", null)
     .attr("width", null)
-    .attr("viewBox", `0 0 ${layout.height} ${layout.width}`);
-  console.log('adjusted')
+    .attr("viewBox", `0 0 ${layout.width} ${layout.height}`);
 }
 
 function setPlotlyTraces(traces = []) {
-  Plotly.newPlot(plotyGraph, traces, layout, plotlyConfig).then(adjustPlotlyChart);
+  return Plotly.react(plotyGraph, traces, layout, plotlyConfig).then(makePlotlyReactive);
 }
 
-setPlotlyTraces()
+setPlotlyTraces();
 
 // Checks if the max and traces have been loaded and preprocessed for the given region;
 // if not, loads them and does preprocessing; then caches it in the region object.

--- a/src/server/static/js/lines.js
+++ b/src/server/static/js/lines.js
@@ -9,8 +9,9 @@ const CHANNEL_PARAM = "channel";
 const REGION_FALLBACK = "united kingdom";
 
 // Set starting chart size based on screen size
-const CHART_HEIGHT_RATIO = Math.max(0.5, Math.min(1, window.innerHeight / window.innerWidth));
-const CHART_WIDTH = Math.max(500, Math.min(1000, window.innerWidth * 0.6));
+const CHART_CONTAINER = document.getElementById("my_dataviz");
+const CHART_HEIGHT_RATIO = Math.max(0.5, Math.min(1, window.innerHeight / CHART_CONTAINER.clientWidth * 0.7));
+const CHART_WIDTH = Math.max(500, Math.min(1000, window.innerWidth * 0.5));
 const CHART_HEIGHT = Math.round(CHART_WIDTH * CHART_HEIGHT_RATIO);
 
 function getUrlParams() {
@@ -160,9 +161,6 @@ const formatAbsoluteInteger = function (number) {
   }
 };
 
-// graph
-var plotlyGraph = document.getElementById("my_dataviz");
-
 // graph layout
 var layout = {
   width: CHART_WIDTH,
@@ -250,11 +248,11 @@ function makePlotlyReactive() {
     .attr("viewBox", `0 0 ${layout.width} ${layout.height}`);
 }
 
-function setPlotlyTraces(traces = []) {
-  return Plotly.react(plotyGraph, traces, layout, plotlyConfig).then(makePlotlyReactive);
+function renderChart(traces = []) {
+  return Plotly
+    .react(CHART_CONTAINER, traces, layout, plotlyConfig)
+    .then(makePlotlyReactive);
 }
-
-setPlotlyTraces();
 
 // Checks if the max and traces have been loaded and preprocessed for the given region;
 // if not, loads them and does preprocessing; then caches it in the region object.
@@ -340,7 +338,7 @@ function updatePlot() {
     layout.yaxis.range = [0, maxVal];
     AddCriticalCareTrace(mitigTraces[mitigationId]);
     // redraw the lines on the graph
-    setPlotlyTraces(mitigTraces[mitigationId]);
+    renderChart(mitigTraces[mitigationId]);
   });
 }
 

--- a/src/server/static/js/lines.js
+++ b/src/server/static/js/lines.js
@@ -160,6 +160,7 @@ var plotyGraph = document.getElementById("my_dataviz");
 // graph layout
 var layout = {
   height: 600,
+  width: 600,
   //margin: { t: 0 },
   paper_bgcolor: "#222028",
   plot_bgcolor: "#222028",
@@ -226,11 +227,25 @@ var layout = {
 
 var plotlyConfig = {
   displaylogo: false,
-  responsive: true,
+  responsive: false,
   scrollZoom: false
 };
 
-Plotly.newPlot(plotyGraph, [], layout, plotlyConfig);
+function adjustPlotlyChart() {
+  d3.select(".js-plotly-plot .plotly .svg-container")
+    .attr("style", null);
+  d3.selectAll(".js-plotly-plot .plotly .main-svg")
+    .attr("height", null)
+    .attr("width", null)
+    .attr("viewBox", `0 0 ${layout.height} ${layout.width}`);
+  console.log('adjusted')
+}
+
+function setPlotlyTraces(traces = []) {
+  Plotly.newPlot(plotyGraph, traces, layout, plotlyConfig).then(adjustPlotlyChart);
+}
+
+setPlotlyTraces()
 
 // Checks if the max and traces have been loaded and preprocessed for the given region;
 // if not, loads them and does preprocessing; then caches it in the region object.
@@ -313,7 +328,7 @@ function updatePlot() {
     layout.yaxis.range = [0, maxVal];
     AddCriticalCareTrace(mitigTraces[mitigationId]);
     // redraw the lines on the graph
-    Plotly.newPlot(plotyGraph, mitigTraces[mitigationId], layout, plotlyConfig);
+    setPlotlyTraces(mitigTraces[mitigationId]);
   });
 }
 
@@ -472,7 +487,7 @@ function restyleDropdownElements() {
     }
 
     if(index === focusedRegionIdx){
-      className += " active"; 
+      className += " active";
 
       // TODO something like this:
       // dropdownEntry.scrollIntoView(false);
@@ -482,7 +497,7 @@ function restyleDropdownElements() {
   })
 }
 
-$regionFilter.addEventListener("keyup", () => { 
+$regionFilter.addEventListener("keyup", () => {
   if(filterQuery === $regionFilter.value){
     // dont do anything if the query didnt change
     return;
@@ -512,7 +527,7 @@ $regionFilter.addEventListener("keydown", evt => {
 
     restyleDropdownElements();
   }
-  
+
   else if (evt.key === "ArrowDown") {
     focusedRegionIdx = Math.min(focusedRegionIdx + 1, regionList.length - 1);
 
@@ -557,7 +572,7 @@ Promise.all([`data-${selected.channel}-v3.json`, "data-manual-estimates-v1.json"
 
   // populate the dropdown menu with countries from received data
   let listOfRegions = Object.keys(baseData.regions);
-  listOfRegions.forEach((key) => 
+  listOfRegions.forEach((key) =>
     addRegionDropdown(key, baseData.regions[key].name)
   );
 


### PR DESCRIPTION
Fixes #314 

Plotly has a `responsive` configuration option but its implementation is pretty bad. As a constraint of this, the plot always has the same height in pixels, regardless of the width. This leads to really skewed aspect ratios on small and large screens.

The PR takes advantage of SVG's `viewBox` attribute to maintain aspect ratio and responsively resize through CSS. It also intelligently choses a size and aspect ratio based on the starting screen size so that the text doesn't become too large or small and the ratio remains usable.

On wide screen:
![chart on wide screen](https://user-images.githubusercontent.com/4276302/78050122-b88b9000-7330-11ea-9202-8af0215377b1.png)

On narrow screen:
![chart on narrow screen](https://user-images.githubusercontent.com/4276302/78050188-c7724280-7330-11ea-9934-5be553865a3d.png)
