### PR TITLE
Add HTTPS/TLS

### DIFF
--- a/deploy/chart/templates/configmap.yaml
+++ b/deploy/chart/templates/configmap.yaml
@@ -5,3 +5,4 @@ metadata:
 data:
   APP_VERSION: {{ .Chart.AppVersion | quote }}
   STATIC_URL: {{ .Values.env.staticUrl | quote }}
+  ALLOWED_HOSTS: {{ .Values.ingress.tlsDomainName | quote }}

--- a/deploy/chart/templates/ingress.yaml
+++ b/deploy/chart/templates/ingress.yaml
@@ -11,6 +11,10 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.externalIpName }}
 spec:
+  tls:
+  - hosts:
+    - {{ .Values.ingress.tlsDomainName }}
+    secretName: cert-epidemics
   rules:
   -  http:
         paths:

--- a/deploy/chart/values.production.yaml
+++ b/deploy/chart/values.production.yaml
@@ -1,6 +1,7 @@
 ingress:
   # reserved in GCP, note the differences between loadbalanceR and loadbalance-staging (no R)
   externalIpName: loadbalancer
+  tlsDomainName: epidemicforecasting.org
 
 web:
   replicasCount: 3

--- a/deploy/chart/values.staging.yaml
+++ b/deploy/chart/values.staging.yaml
@@ -1,6 +1,8 @@
 ingress:
   # reserved in GCP, note that I forgot `r` at the end
   externalIpName: loadbalance-staging
+  tlsDomainName: staging.epidemicforecasting.org
+
 
 web:
   replicasCount: 2

--- a/deploy/chart/values.staging.yaml
+++ b/deploy/chart/values.staging.yaml
@@ -9,4 +9,3 @@ web:
 
 env:
   staticUrl: "https://storage.googleapis.com/static-covid/static/staging"
-

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -35,4 +35,5 @@ class Config(BaseConfig):
     # comma separated string of addresses
     ALLOWED_HOSTS: str = "127.0.0.1"
 
+
 CONFIG = Config()

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -31,9 +31,8 @@ class BaseConfig:
 @dataclass(init=False)
 class Config(BaseConfig):
     APP_VERSION: str = "000000"
-    ENABLE_NOTION: bool = False
 
-    NOTION_TOKEN: str = "xxx"
-
+    # comma separated string of addresses
+    ALLOWED_HOSTS: str = "127.0.0.1"
 
 CONFIG = Config()

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -5,38 +5,11 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.responses import RedirectResponse, Response
 from fastapi.middleware.gzip import GZipMiddleware
+from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
+
 
 from server.config import CONFIG
-
-
-class ProxyHeadersMiddleware:
-    def __init__(self, app, trusted_hosts="127.0.0.1"):
-        self.app = app
-        if isinstance(trusted_hosts, str):
-            self.trusted_hosts = [item.strip() for item in trusted_hosts.split(",")]
-        else:
-            self.trusted_hosts = trusted_hosts
-        self.always_trust = "*" in self.trusted_hosts
-
-    async def __call__(self, scope, receive, send):
-        if scope["type"] in ("http", "websocket"):
-            client_addr = scope.get("client")
-            client_host = client_addr[0] if client_addr else None
-
-            if self.always_trust or client_host in self.trusted_hosts:
-                headers = dict(scope["headers"])
-
-                if b"x-forwarded-proto" in headers:
-                    x_forwarded_proto = headers[b"x-forwarded-proto"].decode("ascii")
-                    scope["scheme"] = x_forwarded_proto.strip()
-
-                if b"x-forwarded-for" in headers:
-                    x_forwarded_for = headers[b"x-forwarded-for"].decode("ascii")
-                    host = x_forwarded_for.split(",")[-1].strip()
-                    port = 0
-                    scope["client"] = (host, port)
-
-        return await self.app(scope, receive, send)
+from server.proxy_middleware import ProxyHeadersMiddleware
 
 
 STATIC_URL = os.getenv("STATIC_URL", "/static")
@@ -47,6 +20,7 @@ app.mount(
     "/static", StaticFiles(directory=os.path.join(SERVER_ROOT, "static")), name="static"
 )
 
+app.add_middleware(HTTPSRedirectMiddleware)
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=CONFIG.ALLOWED_HOSTS)
 app.add_middleware(GZipMiddleware, minimum_size=500)
 

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -9,6 +9,36 @@ from fastapi.middleware.gzip import GZipMiddleware
 from server.config import CONFIG
 
 
+class ProxyHeadersMiddleware:
+    def __init__(self, app, trusted_hosts="127.0.0.1"):
+        self.app = app
+        if isinstance(trusted_hosts, str):
+            self.trusted_hosts = [item.strip() for item in trusted_hosts.split(",")]
+        else:
+            self.trusted_hosts = trusted_hosts
+        self.always_trust = "*" in self.trusted_hosts
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] in ("http", "websocket"):
+            client_addr = scope.get("client")
+            client_host = client_addr[0] if client_addr else None
+
+            if self.always_trust or client_host in self.trusted_hosts:
+                headers = dict(scope["headers"])
+
+                if b"x-forwarded-proto" in headers:
+                    x_forwarded_proto = headers[b"x-forwarded-proto"].decode("ascii")
+                    scope["scheme"] = x_forwarded_proto.strip()
+
+                if b"x-forwarded-for" in headers:
+                    x_forwarded_for = headers[b"x-forwarded-for"].decode("ascii")
+                    host = x_forwarded_for.split(",")[-1].strip()
+                    port = 0
+                    scope["client"] = (host, port)
+
+        return await self.app(scope, receive, send)
+
+
 STATIC_URL = os.getenv("STATIC_URL", "/static")
 SERVER_ROOT = os.path.dirname(__file__)
 
@@ -16,7 +46,9 @@ app = FastAPI()
 app.mount(
     "/static", StaticFiles(directory=os.path.join(SERVER_ROOT, "static")), name="static"
 )
-app.add_middleware(GZipMiddleware, minimum_size=1000)
+
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=CONFIG.ALLOWED_HOSTS)
+app.add_middleware(GZipMiddleware, minimum_size=500)
 
 templates = Jinja2Templates(directory=os.path.join(SERVER_ROOT, "templates"))
 

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -5,7 +5,6 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.responses import RedirectResponse, Response
 from fastapi.middleware.gzip import GZipMiddleware
-from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 
 
 from server.config import CONFIG
@@ -20,7 +19,6 @@ app.mount(
     "/static", StaticFiles(directory=os.path.join(SERVER_ROOT, "static")), name="static"
 )
 
-app.add_middleware(HTTPSRedirectMiddleware)
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=CONFIG.ALLOWED_HOSTS)
 app.add_middleware(GZipMiddleware, minimum_size=500)
 

--- a/src/server/proxy_middleware.py
+++ b/src/server/proxy_middleware.py
@@ -1,0 +1,33 @@
+class ProxyHeadersMiddleware:
+    """Needed for HTTPS to work properly
+
+    See starlette docs: https://www.starlette.io/middleware/#proxyheadersmiddleware
+    """
+
+    def __init__(self, app, trusted_hosts="127.0.0.1"):
+        self.app = app
+        if isinstance(trusted_hosts, str):
+            self.trusted_hosts = [item.strip() for item in trusted_hosts.split(",")]
+        else:
+            self.trusted_hosts = trusted_hosts
+        self.always_trust = "*" in self.trusted_hosts
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] in ("http", "websocket"):
+            client_addr = scope.get("client")
+            client_host = client_addr[0] if client_addr else None
+
+            if self.always_trust or client_host in self.trusted_hosts:
+                headers = dict(scope["headers"])
+
+                if b"x-forwarded-proto" in headers:
+                    x_forwarded_proto = headers[b"x-forwarded-proto"].decode("ascii")
+                    scope["scheme"] = x_forwarded_proto.strip()
+
+                if b"x-forwarded-for" in headers:
+                    x_forwarded_for = headers[b"x-forwarded-for"].decode("ascii")
+                    host = x_forwarded_for.split(",")[-1].strip()
+                    port = 0
+                    scope["client"] = (host, port)
+
+        return await self.app(scope, receive, send)


### PR DESCRIPTION
Solves #16 

1. the certificates are loaded in GCP as secrets
2. this PR adds them to the ingress
3. but the page doesn't load because uvicorn likely needs to be setup to run [over HTTPS](https://www.uvicorn.org/deployment/#running-with-https)
4. would be great to [add a middleware HTTP -> HTTPS](https://www.starlette.io/middleware/#httpsredirectmiddleware)


Consideration:
* we have to make sure we don't have a downtime