### PR TITLE
Improve graph on small screens

### DIFF
--- a/src/frontend/lines.ts
+++ b/src/frontend/lines.ts
@@ -162,6 +162,7 @@ function controlModelVisualization($container: HTMLElement){
   var layout: Partial<Plotly.Layout> = {
     ...calculateChartSize(),
     //margin: { t: 0 },
+    margin: {r: 20},
     paper_bgcolor: "#222028",
     plot_bgcolor: "#222028",
     xaxis: {
@@ -189,7 +190,7 @@ function controlModelVisualization($container: HTMLElement){
       title: "Active infections (% of population)",
       titlefont: {
         family: "DM Sans, sans-serif",
-        size: 18,
+        size: 16,
         color: "white"
       },
       tickfont: {
@@ -211,8 +212,8 @@ function controlModelVisualization($container: HTMLElement){
       zeroline: true,
       zerolinecolor: "#fff",
       zerolinewidth: 1,
-
-      range: [0, 1]
+      // this way the axis does not change width on data load
+      range: [0, 0.099]
     },
     showlegend: true,
     legend: {

--- a/src/frontend/lines.ts
+++ b/src/frontend/lines.ts
@@ -12,14 +12,10 @@ const MITIGATION_PARAM = "mitigation";
 const CHANNEL_PARAM = "channel";
 const REGION_FALLBACK = "united kingdom";
 
-function controlModelVisualization($container: HTMLElement) {
-  // Set starting chart size based on screen size
-  const CHART_HEIGHT_RATIO = Math.max(
-    0.5,
-    Math.min(1, (window.innerHeight / $container.clientWidth) * 0.7)
-  );
-  const CHART_WIDTH = Math.max(500, Math.min(1000, window.innerWidth * 0.5));
-  const CHART_HEIGHT = Math.round(CHART_WIDTH * CHART_HEIGHT_RATIO);
+const MAX_CHART_WIDTH_RATIO = 2;
+const MAX_CHART_HEIGHT_RATIO = 1;
+
+function controlModelVisualization($container: HTMLElement){
 
   function getUrlParams() {
     let urlString = window.location.href;
@@ -163,8 +159,7 @@ function controlModelVisualization($container: HTMLElement) {
 
   // graph layout
   var layout: Partial<Plotly.Layout> = {
-    width: CHART_WIDTH,
-    height: CHART_HEIGHT,
+    ...calculateChartSize(),
     //margin: { t: 0 },
     paper_bgcolor: "#222028",
     plot_bgcolor: "#222028",
@@ -293,22 +288,25 @@ function controlModelVisualization($container: HTMLElement) {
     modeBarButtonsToRemove: ["toImage"]
   };
 
-  function makePlotlyReactive() {
-    d3.select("#my_dataviz").style(
-      "padding-bottom",
-      `${(CHART_HEIGHT / CHART_WIDTH) * 100}%`
-    );
-    d3.select(".js-plotly-plot .plotly .svg-container").attr("style", null);
-    d3.selectAll(".js-plotly-plot .plotly .main-svg")
-      .attr("height", null)
-      .attr("width", null)
-      .attr("viewBox", `0 0 ${layout.width} ${layout.height}`);
+  function renderChart(traces = []) {
+    return Plotly.react($container, traces, layout, plotlyConfig)
   }
 
-  function renderChart(traces = []) {
-    return Plotly.react($container, traces, layout, plotlyConfig).then(
-      makePlotlyReactive
-    );
+  window.addEventListener('resize', () => {
+    const size = calculateChartSize();
+    Object.assign(layout, size);
+    Plotly.relayout($container, size);
+  });
+
+  function calculateChartSize() {
+    const idealWidth = $container.clientWidth;
+    const idealHeight = window.innerHeight * 0.7;
+    const maxWidth = idealHeight * MAX_CHART_WIDTH_RATIO;
+    const maxHeight = idealWidth * MAX_CHART_HEIGHT_RATIO;
+    return {
+      width: Math.min(idealWidth, maxWidth),
+      height: Math.min(idealHeight, maxHeight)
+    };
   }
 
   // Checks if the max and traces have been loaded and preprocessed for the given region;

--- a/src/frontend/lines.ts
+++ b/src/frontend/lines.ts
@@ -301,8 +301,6 @@ function controlModelVisualization($container: HTMLElement){
   }
 
   function makePlotlyResponsive() {
-    d3.select("#my_dataviz")
-      .style('padding-bottom', `${layout.height / layout.width * 100}%`);
     d3.select(".js-plotly-plot .plotly .svg-container")
       .attr("style", null);
     d3.selectAll(".js-plotly-plot .plotly .main-svg")

--- a/src/frontend/lines.ts
+++ b/src/frontend/lines.ts
@@ -312,13 +312,16 @@ function controlModelVisualization($container: HTMLElement){
   }
 
 
-  function renderChart(traces) {
+  function renderChart(traces = []) {
     Plotly.react($container, traces, layout, plotlyConfig)
       .then(makePlotlyResponsive);
   }
 
   renderChart();
+  // `on` is not part of the HTMLElement interface, but Plotly adds it
+  // @ts-ignore
   $container.on('plotly_restyle', makePlotlyResponsive);
+  // @ts-ignore
   $container.on('plotly_relayout', makePlotlyResponsive);
 
   window.addEventListener('resize', () => {

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -273,10 +273,6 @@ span.infections-confirmed {
   justify-content: space-evenly;
 }
 
-#my_dataviz {
-  width: 100%;
-}
-
 .mitigation-strength-heading {
   font-size: 24px;
 }
@@ -752,6 +748,11 @@ strong {
   .main-wrapper {
     padding: 15px 15px;
   }
+
+  #my_dataviz{
+    margin: 0 -24px;
+  }
+
   .detail-button {
     text-align: left
   }
@@ -832,9 +833,6 @@ div.tooltip {
 }
 
 #my_dataviz {
-  width: 100%;
-  height: 0;
-  padding-bottom: 100%;
   vertical-align: top;
   overflow: hidden;
 }

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -831,6 +831,23 @@ div.tooltip {
   opacity: 0.2;
 }
 
+#my_dataviz {
+  width: 100%;
+  height: 0;
+  padding-bottom: 100%;
+  vertical-align: top;
+  overflow: hidden;
+}
+
+.js-plotly-plot .plotly .svg-container {
+  position: relative;
+}
+
+.js-plotly-plot .plotly .main-svg:first-child {
+  position: relative;
+}
+
+
 /*
 * General
 */

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -831,41 +831,6 @@ div.tooltip {
   opacity: 0.2;
 }
 
-#my_dataviz {
-  width: 100%;
-  height: 0;
-  padding-bottom: 100%;
-  vertical-align: top;
-  overflow: hidden;
-}
-
-.js-plotly-plot .plotly .svg-container {
-  position: relative;
-}
-
-.js-plotly-plot .plotly .main-svg:first-child {
-  position: relative;
-}
-
-/*
-@media only screen and (max-width: 767px) {
-  .legend {
-    margin-top: 111%;
-  } */
-
-@media only screen and (min-width: 768px) and (max-width: 991px) {
-  .legend {
-    min-height: 526px;
-  }
-}
-
-@media only screen and (max-width: 767px) {
-  .legend {
-    margin-top: 20px;
-    margin-bottom: 18px;
-  }
-}
-
 /*
 * General
 */


### PR DESCRIPTION
Follow-up to #349

- Collapses the left and right margins on small screens
- Tighten right margin, especially useful for mobile
- Sligthly decrease y-axis label
- Make the standard range more natural so that it looks better when the data loads

before:
![Screen Shot 2020-04-04 at 11 47 12](https://user-images.githubusercontent.com/242143/78423960-759c2600-766a-11ea-9680-44e5faf6b39a.png)

after:
![Screen Shot 2020-04-04 at 11 46 50](https://user-images.githubusercontent.com/242143/78423962-78971680-766a-11ea-9c02-241f7befc470.png)

