### PR TITLE
Adjust request calculation copy

### DIFF
--- a/frontend/page_measures/MeasuresPage.tsx
+++ b/frontend/page_measures/MeasuresPage.tsx
@@ -97,8 +97,7 @@ export function MeasuresPage({ data }: { data: Datastore }) {
         revision="0"
       >
         <p>
-          We're offering pro bono consulting services and custom forecasts for
-          decision-makers. Please reach out{" "}
+          Are you a decision maker? We're offering pro bono custom forecasting and modelling. Please reach out{" "}
           <a
             href="http://epidemicforecasting.org/request-calculation"
             className="alert-link"

--- a/frontend/page_measures/MeasuresPage.tsx
+++ b/frontend/page_measures/MeasuresPage.tsx
@@ -97,7 +97,8 @@ export function MeasuresPage({ data }: { data: Datastore }) {
         revision="0"
       >
         <p>
-          Are you a decision maker? We're offering pro bono custom forecasting and modelling. Please reach out{" "}
+          Are you a decision maker? We're offering pro bono custom forecasting
+          and modelling. Please reach out{" "}
           <a
             href="http://epidemicforecasting.org/request-calculation"
             className="alert-link"

--- a/frontend/page_models/ModelsPage.tsx
+++ b/frontend/page_models/ModelsPage.tsx
@@ -120,8 +120,7 @@ export function Page() {
         revision="0"
       >
         <p>
-          We're offering pro bono consulting services and custom forecasts for
-          decision-makers. Please reach out{" "}
+          Are you a decision maker? We're offering pro bono custom forecasting and modelling. Please reach out{" "}
           <a
             href="http://epidemicforecasting.org/request-calculation"
             className="alert-link"

--- a/frontend/page_models/ModelsPage.tsx
+++ b/frontend/page_models/ModelsPage.tsx
@@ -120,7 +120,8 @@ export function Page() {
         revision="0"
       >
         <p>
-          Are you a decision maker? We're offering pro bono custom forecasting and modelling. Please reach out{" "}
+          Are you a decision maker? We're offering pro bono custom forecasting
+          and modelling. Please reach out{" "}
           <a
             href="http://epidemicforecasting.org/request-calculation"
             className="alert-link"

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -48,13 +48,13 @@ add(MODELS, { path: "/", caption: "Models" }, (req, res) =>
   res.render("model.html")
 );
 
-add(CASE_MAP, { path: "/case-map", caption: "Case Map" }, (req, res) =>
+add(CASE_MAP, { path: "/case-map", caption: "Case map" }, (req, res) =>
   res.render("case-map.html")
 );
 
 add(
   MITIGATION_MAP,
-  { path: "/mitigation-map", caption: "Mitigation Map" },
+  { path: "/mitigation-map", caption: "Mitigation map" },
   (req, res) => res.render("mitigation-map.html")
 );
 
@@ -62,7 +62,7 @@ add(MEASURES, { path: "/measures", caption: "Measures" }, (req, res) =>
   res.render("measures.html")
 );
 
-add(MITIGATION, { path: "/containment", caption: "Mitigation Measures" }, (req, res) =>
+add(MITIGATION, { path: "/containment", caption: "Mitigation" }, (req, res) =>
   res.render("containment.html")
 );
 
@@ -74,7 +74,7 @@ router.get("/request-calculation-submitted", (req, res) =>
 
 add(
   REQUEST_MODEL,
-  { path: "/request-calculation", caption: "Request a Model" },
+  { path: "/request-calculation", caption: "Request custom modelling" },
   (req, res) =>
     res.render("request-calculation.html", {
       message: "Please provide data",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -74,7 +74,7 @@ router.get("/request-calculation-submitted", (req, res) =>
 
 add(
   REQUEST_MODEL,
-  { path: "/request-calculation", caption: "Request custom modelling" },
+  { path: "/request-calculation", caption: "Request a model" },
   (req, res) =>
     res.render("request-calculation.html", {
       message: "Please provide data",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -48,13 +48,13 @@ add(MODELS, { path: "/", caption: "Models" }, (req, res) =>
   res.render("model.html")
 );
 
-add(CASE_MAP, { path: "/case-map", caption: "Case map" }, (req, res) =>
+add(CASE_MAP, { path: "/case-map", caption: "Case Map" }, (req, res) =>
   res.render("case-map.html")
 );
 
 add(
   MITIGATION_MAP,
-  { path: "/mitigation-map", caption: "Mitigation map" },
+  { path: "/mitigation-map", caption: "Mitigation Map" },
   (req, res) => res.render("mitigation-map.html")
 );
 
@@ -62,7 +62,7 @@ add(MEASURES, { path: "/measures", caption: "Measures" }, (req, res) =>
   res.render("measures.html")
 );
 
-add(MITIGATION, { path: "/containment", caption: "Mitigation" }, (req, res) =>
+add(MITIGATION, { path: "/containment", caption: "Mitigation Measures" }, (req, res) =>
   res.render("containment.html")
 );
 
@@ -74,7 +74,7 @@ router.get("/request-calculation-submitted", (req, res) =>
 
 add(
   REQUEST_MODEL,
-  { path: "/request-calculation", caption: "Request model" },
+  { path: "/request-calculation", caption: "Request a Model" },
   (req, res) =>
     res.render("request-calculation.html", {
       message: "Please provide data",

--- a/server/templates/request-calculation.html
+++ b/server/templates/request-calculation.html
@@ -4,21 +4,21 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
   <div>
     <div class="row">
       <div class="col-lg-9 col-md-12">
-        <h5>On demand modelling</h5>
+        <h5>Request custom forecasting and modelling</h5>
         <p>
-          Our team of Oxford researchers and volunteer data scientists are happy
-          to provide custom forecasting and modelling support for decision
-          makers in government, international organisations, health care, and
-          others.
+          Are you a decision maker in government, in health care, or at an international organisation?
         </p>
         <p>
-          By using <a href="/">a global epidemic model</a>, we can analyse
+          Our team of Oxford researchers and volunteer data scientists can provide you with pro bono custom forecasting and modelling to help inform your decision making.
+        </p>
+        <p>
+          We use <a href="/">a global epidemic model</a>, where we can analyse
           scenarios like demand for ICUs and hospital beds, as well as how
           different mitigation strategies implemented in other countries/cities
-          can affect your region.
+          can affect your region. 
         </p>
         <p>
-          In future we also hope to provide estimates on effectiveness of
+          In the future, we also hope to provide estimates on effectiveness of
           various containment and mitigation measures, as tracked in our
           <a href="/containment">public database</a>.
         </p>
@@ -44,19 +44,8 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
           <input
             class="fill-available-width"
             type="text"
-            placeholder="Your name"
+            placeholder="Full Name"
             name="name"
-          />
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="col-lg-6">
-          <input
-            class="fill-available-width"
-            type="text"
-            name="affiliation"
-            placeholder="Affiliation"
           />
         </div>
       </div>
@@ -67,7 +56,7 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
             type="email"
             class="fill-available-width"
             name="email"
-            placeholder="Your email address"
+            placeholder="Email Address"
           />
         </div>
       </div>
@@ -75,10 +64,10 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
       <div class="row">
         <div class="col-lg-6">
           <input
-            type="text"
             class="fill-available-width"
-            name="messaging"
-            placeholder="Online messaging platform"
+            type="text"
+            name="affiliation"
+            placeholder="Affiliation or Company"
           />
         </div>
       </div>
@@ -89,7 +78,7 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
             type="text"
             class="fill-available-width"
             name="verify"
-            placeholder="Link or some other way how we can verify your affiliation"
+            placeholder="Website"
           />
         </div>
       </div>
@@ -99,7 +88,7 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
           <textarea
             class="fill-available-width"
             name="problem"
-            placeholder="What decision problem are you facing"
+            placeholder="What decision or problem are you facing?"
           ></textarea>
         </div>
       </div>

--- a/server/templates/request-calculation.html
+++ b/server/templates/request-calculation.html
@@ -42,7 +42,7 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
       <div class="row">
         <div class="col-lg-6">
           <input
-            class="fill-available-width"
+            class="form-control form-control-md"
             type="text"
             placeholder="Full Name"
             name="name"
@@ -54,7 +54,7 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
         <div class="col-lg-6">
           <input
             type="email"
-            class="fill-available-width"
+            class="form-control form-control-md"
             name="email"
             placeholder="Email Address"
           />
@@ -64,7 +64,7 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
       <div class="row">
         <div class="col-lg-6">
           <input
-            class="fill-available-width"
+            class="form-control form-control-md"
             type="text"
             name="affiliation"
             placeholder="Affiliation or Company"
@@ -76,7 +76,7 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
         <div class="col-lg-6">
           <input
             type="text"
-            class="fill-available-width"
+            class="form-control form-control-md"
             name="verify"
             placeholder="Website"
           />
@@ -86,9 +86,10 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
       <div class="row">
         <div class="col-lg-6">
           <textarea
-            class="fill-available-width"
+            class="form-control form-control-md"
             name="problem"
             placeholder="What decision or problem are you facing?"
+            rows="5"
           ></textarea>
         </div>
       </div>
@@ -96,9 +97,10 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
       <div class="row">
         <div class="col-lg-6">
           <textarea
-            class="fill-available-width"
+            class="form-control form-control-md"
             name="modeling"
             placeholder="Are you are already using epidemic modelling to support your decisions? How?"
+            rows="5"
           ></textarea>
         </div>
       </div>

--- a/server/templates/request-calculation.html
+++ b/server/templates/request-calculation.html
@@ -4,7 +4,7 @@ block additional_js_pre -%} {%- endblock -%} {%- block content -%}
   <div>
     <div class="row">
       <div class="col-lg-9 col-md-12">
-        <h5>Request custom forecasting and modelling</h5>
+        <h5>Request custom modelling</h5>
         <p>
           Are you a decision maker in government, in health care, or at an international organisation?
         </p>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -546,13 +546,8 @@ label {
 .btn-primary,
 .btn-secondary {
   padding: 11px 20px;
-  border-radius: 0px;
 }
 
-select,
-input {
-  border-radius: 0px !important;
-}
 
 label.btn-secondary > input {
   display: none;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -548,7 +548,6 @@ label {
   padding: 11px 20px;
 }
 
-
 label.btn-secondary > input {
   display: none;
 }


### PR DESCRIPTION
This PR: 
- Updates the copy and form descriptions on the request calculation page to be clearer. 
- Removes the "Messaging" field as this field wasn't useful based on the Formspree responses.
- Updates "Request model" to "Request a model" in navbar
- Updates the banner text to be targetted to decision makers `Are you a decision maker? We're offering pro bono custom forecasting and modelling. Please reach out here`

## Before
<img width="804" alt="Screen Shot 2020-04-27 at 12 22 05 AM" src="https://user-images.githubusercontent.com/8121736/80345011-5170d680-881d-11ea-9200-8b0ff21a5a73.png">

## After
<img width="884" alt="Screen Shot 2020-04-27 at 12 26 14 AM" src="https://user-images.githubusercontent.com/8121736/80345273-bdebd580-881d-11ea-8517-3e0d6e513134.png">

Closes #370 

