### PR TITLE
Jeromezng update about containment forms

### DIFF
--- a/server/templates/about.html
+++ b/server/templates/about.html
@@ -138,7 +138,7 @@ block additional_js_pre -%}
       </div>
       <br />
       <button type="submit" class="btn btn-primary">
-        Send
+        Submit
       </button>
     </form>
     <br />

--- a/server/templates/about.html
+++ b/server/templates/about.html
@@ -115,25 +115,28 @@ block additional_js_pre -%}
         name="_next" 
         value="/about-submitted"
       />
-      <label class="fill-available-width">Your email address:</label>
       <div class="row">
         <div class="col-lg-6">
-          <input class="fill-available-width" type="text" name="_replyto" />
+          <input 
+            class="form-control form-control-md" 
+            type="text" 
+            name="_replyto" 
+            placeholder="Your email address"
+          />
         </div>
       </div>
       <br />
-      <br />
-      <label class="fill-available-width">Your message:</label>
       <div class="row">
         <div class="col-lg-6">
-          <textarea class="fill-available-width" name="message"></textarea>
+          <textarea 
+            class="form-control form-control-md" 
+            name="message" 
+            rows="5"
+            placeholder="Your message"
+          ></textarea>
         </div>
       </div>
-
-      <!-- your other form fields go here -->
       <br />
-      <br />
-
       <button type="submit" class="btn btn-primary">
         Send
       </button>

--- a/server/templates/containment.html
+++ b/server/templates/containment.html
@@ -144,7 +144,7 @@ block additional_js_pre -%}
           </div>
         <br />
         <button type="submit" class="btn btn-primary">
-          Send
+          Submit
         </button>
       </form>
 

--- a/server/templates/containment.html
+++ b/server/templates/containment.html
@@ -119,24 +119,30 @@ block additional_js_pre -%}
         If you'd like to volunteer to extend the dataset, or have any questions
         about usage, please reach out using this form.
       </p>
+
       <form action="https://formspree.io/moqnwzlb" method="POST">
-          <label class="fill-available-width">Your email</label>
           <div class="row">
               <div class="col-lg-6">
-                  <input class="fill-available-width" type="text" name="_replyto" />
+                  <input 
+                    class="form-control form-control-md" 
+                    type="text" 
+                    name="_replyto" 
+                    placeholder="Your email address"
+                  />
               </div>
           </div>
           <br />
-          <label class="fill-available-width">Message</label>
           <div class="row">
               <div class="col-lg-6">
-                  <textarea class="fill-available-width" name="message"></textarea>
+                  <textarea 
+                    class="form-control form-control-md"
+                    rows="5"
+                    name="message"
+                    placeholder="Your message"
+                  ></textarea>
               </div>
           </div>
-
-        <!-- your other form fields go here -->
         <br />
-
         <button type="submit" class="btn btn-primary">
           Send
         </button>


### PR DESCRIPTION
This PR styles the forms on /about and /containment pages by removing labels, utilizing bootstrap form styles, and renaming the 'Send' button to 'Submit'

## Before 
<img width="563" alt="Screen Shot 2020-04-27 at 7 16 13 PM" src="https://user-images.githubusercontent.com/8121736/80439525-98150e00-88bb-11ea-9aa8-80d38e930808.png">
<img width="773" alt="Screen Shot 2020-04-27 at 7 16 20 PM" src="https://user-images.githubusercontent.com/8121736/80439526-98ada480-88bb-11ea-9bcd-0d77f8fc6385.png">

## After
<img width="875" alt="Screen Shot 2020-04-27 at 7 15 27 PM" src="https://user-images.githubusercontent.com/8121736/80439479-7ae03f80-88bb-11ea-9fcd-08621c6b3305.png">
<img width="859" alt="Screen Shot 2020-04-27 at 7 15 20 PM" src="https://user-images.githubusercontent.com/8121736/80439481-7b78d600-88bb-11ea-9633-a568803eae7e.png">


