### PR TITLE
Round large y-axis to no decimals

### DIFF
--- a/frontend/components/graph-common.ts
+++ b/frontend/components/graph-common.ts
@@ -15,7 +15,21 @@ export type Bounds = {
   y: Plotly.Range;
 };
 
-export function makeLayout(bounds?: Bounds): Partial<Plotly.Layout> {
+export type TickFormatStops = {
+  enabled: boolean;
+  dtickrange: (number | null)[];
+  value: string;
+};
+
+export interface YAxis extends Plotly.LayoutAxis {
+  tickformatstops: TickFormatStops[];
+}
+
+export interface Layout extends Plotly.Layout {
+  yaxis: Partial<YAxis>;
+}
+
+export function makeLayout(bounds?: Bounds): Partial<Layout> {
   return {
     margin: { t: 40 },
     paper_bgcolor: "#222028",
@@ -44,6 +58,13 @@ export function makeLayout(bounds?: Bounds): Partial<Plotly.Layout> {
       linecolor: "#fff",
     },
     yaxis: {
+      tickformatstops: [
+        {
+          enabled: true,
+          dtickrange: [null, null],
+          value: "",
+        },
+      ],
       title: "Active spreaders (% of population)",
       titlefont: {
         family: "DM Sans, sans-serif",

--- a/frontend/page_models/ModelView.tsx
+++ b/frontend/page_models/ModelView.tsx
@@ -138,7 +138,11 @@ export function ModelView(props: ModelViewProps) {
   layout.margin!.r = 20;
   layout.xaxis!.type = "date";
   layout.yaxis!.title = `${plotKinds[plotKind]} infections (% of population)`;
-  layout.yaxis!.tickformat = ".1%";
+  layout.yaxis!.tickformatstops = [
+    { enabled: true, dtickrange: [null, 0.001], value: ".2%" },
+    { enabled: true, dtickrange: [0.001, 0.01], value: ".1%" },
+    { enabled: true, dtickrange: [0.01, null], value: ".0%" },
+  ];
   layout.showlegend = true;
   layout.legend = {
     x: 1,
@@ -194,6 +198,7 @@ export function ModelView(props: ModelViewProps) {
       {Object.keys(plotKinds).map((kind: PlotKind) => (
         <button
           type="button"
+          key={kind}
           onClick={() => setPlotKind(kind)}
           className={classNames("btn btn-secondary", {
             active: plotKind === kind,


### PR DESCRIPTION
rounds the y-axis to no significant digits for larger numbers e.g  “70%” instead of “70.0%“
Still zooms in on smaller numbers (e.g. the 0%-1% range) it shows more decimals.

#430 