### PR TITLE
use created instead of generated since generated does not exist

### DIFF
--- a/frontend/components/RegionSelector.tsx
+++ b/frontend/components/RegionSelector.tsx
@@ -150,7 +150,7 @@ export function RegionSelector({
   );
 
   let current = selected?.current;
-  let generated = current?.date ?? mainInfo.generated;
+  let created = current?.date ?? mainInfo.created;
 
   return (
     <div className="top-row">
@@ -182,7 +182,7 @@ export function RegionSelector({
           <>
             <span className="number-subheader" id="infections-date">
               <span style={{ color: "#aaa" }}>Model last updated on:</span>{" "}
-              {generated ? formatDate(generated) : <>&mdash;</>}
+              {created ? formatDate(created) : <>&mdash;</>}
             </span>
             <div className="active-infections">
               Active Infections:{" "}

--- a/frontend/models/datastore.ts
+++ b/frontend/models/datastore.ts
@@ -2,7 +2,6 @@ import { Regions } from "./regions";
 import * as React from "react";
 
 export type MainInfo = {
-  generated?: Date;
   comment?: string;
   created?: Date;
   created_by?: string;


### PR DESCRIPTION
In the new model exports we are planning to use, some countries do not have a infectious estimate (`selected?.current`). In that case the `mainInfo.generated` is to be used, but it seems that this field was manually added to the json, or by some undocumented process. 
Assuming the generated field will not be generated by the web exports, we should fallback to `mainInfo.created` instead. Alternatively we can add the generated field to the web exports, if it has a different meaning than `mainInfo.created`.

See https://github.com/epidemics/epimodel/blob/39f484507b87d62fe951d34c903123c4f8c79a51/epimodel/exports/epidemics_org.py#L36
In the history I could not find any place where the generated field was added.

The main channel json does actually contain the generated field: https://storage.googleapis.com/static-covid/static/v4/main/data-v4.json which was created by mthq@mthq-desktop, probably @mathijshenquet, maybe he can elaborate on where this field is from and whether created can be used instead of generated.