### PR TITLE
Fix the NPI model run workflow

### DIFF
--- a/.github/workflows/compute-npi-model.yml
+++ b/.github/workflows/compute-npi-model.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+          key: npi-docker-cache
+          continue-on-error: true
+
       - name: Checkout data repo
         uses: actions/checkout@v2
         with:

--- a/data-pipeline/.dockerignore
+++ b/data-pipeline/.dockerignore
@@ -1,2 +1,0 @@
-data-dir
-.git


### PR DESCRIPTION
.dockerignore contained data-dir, so it was not included in the build context, yet it was used in the Dockerfile.conda build so the build failed.