### PR TITLE
Add NPI triggers to GLEAM modelling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.venv

--- a/data-pipeline/epimodel/gleam/batch.py
+++ b/data-pipeline/epimodel/gleam/batch.py
@@ -36,7 +36,7 @@ class Batch:
     """
 
     def __init__(self, hdf_file, path, *, _direct=True):
-        assert not _direct, "Use .new or .load"
+        assert not _direct, "Use .new or .open"
         self.hdf = hdf_file
         self.path = path
 
@@ -70,13 +70,14 @@ class Batch:
         return cls(hdf, path, _direct=False)
 
     @classmethod
-    def new(cls, *, path=None):
+    def new(cls, *, path=None, overwrite=False):
         """
         Create new batch HDF5 file.
         """
         path = Path(path)
 
-        assert not path.exists()
+        if not overwrite:
+            assert not path.exists()
         hdf = pd.HDFStore(path, "w")
         return cls(hdf, path, _direct=False)
 

--- a/data-pipeline/epimodel/gleam/batch.py
+++ b/data-pipeline/epimodel/gleam/batch.py
@@ -255,6 +255,11 @@ class Batch:
 
     @staticmethod
     def generate_sim_stats(cdf: pd.DataFrame, sim_ids: List[str]) -> dict:
+        if np.sum(np.sum(cdf.isna())) > 0:
+            log.warning(
+                f"Creating simulations stats: Unknown daily growths (NaN) are replaced by 0.0"
+            )
+        cdf = cdf.fillna(method="ffill")
         # get the end date of the simulations
         end_date = cdf.index.get_level_values("Date").max()
         # get the infected in the end date for the latest date per simulation

--- a/data-pipeline/epimodel/gleam/npi_triggers.py
+++ b/data-pipeline/epimodel/gleam/npi_triggers.py
@@ -1,0 +1,23 @@
+from .batch import Batch
+import pandas as pd
+import io
+
+
+class NPITriggerConfig:
+    def __init__(self, filename=None, text=None):
+        assert (filename is None) != (text is None)
+        if filename is not None:
+            f = filename
+        else:
+            f = io.StringIO(text)
+        df = pd.read_csv(f, header=0, dtype=str, na_values=[], keep_default_na=False)
+        assert df.columns[0] == "RegionCode"
+        df = df.loc[df.RegionCode != ""]
+        print(df)
+
+    def create_updated_batch(
+        self, in_batch: Batch, out_batch: Batch, truncated_simulations: bool = True
+    ):
+        for k in in_batch.hdf.keys():
+            if k not in ("/simulations", "/triggered_levels"):
+                out_batch.hdf[k] = in_batch.hdf[k]

--- a/data-pipeline/epimodel/gleam/npi_triggers.py
+++ b/data-pipeline/epimodel/gleam/npi_triggers.py
@@ -1,6 +1,14 @@
-from .batch import Batch
-import pandas as pd
 import io
+import logging
+
+import numpy as np
+
+import pandas as pd
+
+from ..regions import Region, RegionDataset
+from .batch import Batch
+
+logger = logging.getLogger(__name__)
 
 
 class NPITriggerConfig:
@@ -11,13 +19,127 @@ class NPITriggerConfig:
         else:
             f = io.StringIO(text)
         df = pd.read_csv(f, header=0, dtype=str, na_values=[], keep_default_na=False)
+        df = df.applymap(lambda s: s.strip())
         assert df.columns[0] == "RegionCode"
         df = df.loc[df.RegionCode != ""]
-        print(df)
+        for c in df.columns:
+            if c not in ("RegionCode", "Group"):
+                df[c] = pd.to_numeric(df[c])
+        # Verify uniqueness
+        _ = df.set_index(["RegionCode", "Group"], verify_integrity=True)
+
+        self.df = df
+        logger.info(
+            f"Loaded NPI triggers for {len(self.df)} regions: {', '.join(self.df.RegionCode.values)}"
+        )
 
     def create_updated_batch(
-        self, in_batch: Batch, out_batch: Batch, truncated_simulations: bool = True
+        self,
+        in_batch: Batch,
+        out_batch: Batch,
+        rds: RegionDataset,
+        truncated_simulations: bool = True,
+        window=14,
     ):
         for k in in_batch.hdf.keys():
-            if k not in ("/simulations", "/triggered_levels"):
+            if k not in ("/new_fraction", "/triggered_NPIs", "/simulations"):
                 out_batch.hdf[k] = in_batch.hdf[k]
+
+        try:
+            triggered = in_batch.hdf.get("triggered_NPIs")
+        except KeyError:
+            triggered = pd.DataFrame(
+                {
+                    "SimulationID": pd.Series([], dtype=str),
+                    "RegionCode": pd.Series([], dtype=str),
+                    "DayNumber": pd.Series([], dtype=np.int32),
+                    "Level": pd.Series([], dtype=np.int32),
+                }
+            )
+        sims = in_batch.hdf.get("simulations")
+        new_fraction = in_batch.hdf.get("new_fraction")
+        new_sims = sims.copy()
+        new_triggered = triggered.copy()
+
+        # For each simulation
+        for sid, simrow in sims.iterrows():
+            group = simrow.Group
+            logger.info(
+                f" Triggers for simulation {sid}: group {group!r}, trace {simrow.Trace!r}"
+            )
+            for _, triggerrow in self.df[self.df.Group == group].iterrows():
+                r = triggerrow.RegionCode
+                td = triggered.loc[triggered.RegionCode == r].sort_values("DayNumber")
+                if len(td) > 0:
+                    last_level = td.Level[-1]
+                    last_day = td.DayNumber[-1]
+                else:
+                    last_level = 0
+                    last_day = 0
+
+                pop = rds[r].Population
+                up_fraction = (
+                    triggerrow.get(f"L{last_level + 1}-Trig-I-14d", np.nan) / pop
+                )
+                down_fraction = (
+                    triggerrow.get(f"L{last_level}-Stop-I-14d", np.nan) / pop
+                )
+
+                window_sums = (
+                    new_fraction.loc[(sid, r)]
+                    .rolling(window, min_periods=0)
+                    .sum()
+                    .Infected
+                )
+                assert len(window_sums) == len(new_fraction.loc[(sid, r)].Infected)
+
+                def switch_to_level(day_no, old_level, level):
+                    nonlocal new_triggered
+                    day = new_fraction.index.levels[2].values[day_no]
+                    logger.info(
+                        f"  Triggered in {r}: L{old_level}->L{level} on day {day_no} ({day})"
+                    )
+                    if truncated_simulations:
+                        new_fraction.loc[
+                            (sid, r, slice(day, None)), "Infected"
+                        ] = np.nan
+                        new_fraction.loc[
+                            (sid, r, slice(day, None)), "Recovered"
+                        ] = np.nan
+                    new_triggered = new_triggered.append(
+                        {
+                            "SimulationID": sid,
+                            "RegionCode": r,
+                            "DayNumber": day_no,
+                            "Level": level,
+                        },
+                        ignore_index=True,
+                    )
+                    # TODO: Add exception to new_sims
+
+                for i in range(last_day + 1, len(window_sums)):
+                    if window_sums[i] > up_fraction:
+                        switch_to_level(i, last_level, last_level + 1)
+                        break
+                    if window_sums[i] < down_fraction:
+                        switch_to_level(i, last_level, last_level - 1)
+                        break
+
+        out_batch.hdf.put(
+            "triggered_NPIs",
+            new_triggered,
+            format="table",
+            complib="bzip2",
+            complevel=4,
+        )
+        out_batch.hdf.put(
+            "simulations", new_sims, format="table", complib="bzip2", complevel=4
+        )
+        if truncated_simulations:
+            out_batch.hdf.put(
+                "new_fraction",
+                new_fraction,
+                format="table",
+                complib="bzip2",
+                complevel=4,
+            )

--- a/data-pipeline/epimodel/tasks.py
+++ b/data-pipeline/epimodel/tasks.py
@@ -510,6 +510,10 @@ class UpdateNPITriggers(luigi.Task):
         "Input gleam batch file (HDF5), with new data from Gleam."
     )
 
+    output_batch: str = luigi.Parameter(
+        "Output gleam batch file (HDF5) with new triggers (and data truncated to valid only). Rerun in GLEAM."
+    )
+
     overwrite: bool = luigi.BoolParameter("Overwrite output batch.")
 
     def __init__(self, *args, **kwargs):
@@ -518,16 +522,10 @@ class UpdateNPITriggers(luigi.Task):
         if not self.input_batch.exists():
             raise Exception(f"Input batch file {self.input_batch} not found.")
 
-        num = re.match(r"^(.*)-([0-9]+)$", self.input_batch.stem)
-        if num:
-            name = f"{num.groups()[0]}-{int(num.groups()[1]) + 1}.hdf5"
-        else:
-            name = f"{self.input_batch.stem}-1.hdf5"
-        self.output_batch = Path(self.input_batch.parent, name)
-
+        self.output_batch = Path(self.output_batch).expanduser()
         if self.output_batch.exists() and not self.overwrite:
             raise Exception(
-                f"Output batch file {self.input_batch} exists; use --overwrite"
+                f"Output batch file {self.output_batch} exists; use --overwrite"
             )
         if self.output_batch.exists():
             assert not self.output_batch.samefile(self.input_batch)

--- a/data-pipeline/epimodel/utils.py
+++ b/data-pipeline/epimodel/utils.py
@@ -1,13 +1,14 @@
 import datetime
 import logging
 import re
-from typing import Union, Set, Optional
+from typing import Optional, Set, Union
 
 import dateutil
-import pandas as pd
-import unidecode
+import numpy as np
 
 import epimodel
+import pandas as pd
+import unidecode
 
 log = logging.getLogger(__name__)
 
@@ -106,16 +107,7 @@ def read_csv_smart(
     na_values = kwargs.pop(
         "na_values",
         ["", "#N/A", "#N/A", "N/A", "#NA", "-NaN", "-nan"]
-        + [
-            "1.#IND",
-            "1.#QNAN",
-            "<NA>",
-            "N/A",
-            "NULL",
-            "NaN",
-            "n/a",
-            "nan",
-        ],
+        + ["1.#IND", "1.#QNAN", "<NA>", "N/A", "NULL", "NaN", "n/a", "nan",],
     )
 
     data = pd.read_csv(path, na_values=na_values, keep_default_na=False, **kwargs)
@@ -204,6 +196,10 @@ def utc_date(d: Union[str, datetime.date, datetime.datetime]) -> datetime.dateti
     Discards any old time and timezone info!
     Note that dates as UTC 00:00:00 is used as the day identifier throughout epimodel.
     """
+    if isinstance(d, np.datetime64):
+        d = pd.Timestamp(d, tz="utc")
+    if isinstance(d, pd.Timestamp):
+        d = d.to_pydatetime()
     if isinstance(d, str):
         d = dateutil.parser.parse(d)
     if isinstance(d, datetime.date):

--- a/data-pipeline/poetry.lock
+++ b/data-pipeline/poetry.lock
@@ -9,7 +9,7 @@ version = "1.4.4"
 [[package]]
 category = "main"
 description = "Disable App Nap on OS X 10.9"
-marker = "python_version >= \"3.3\" and sys_platform == \"darwin\" or platform_system == \"Darwin\""
+marker = "sys_platform == \"darwin\" or platform_system == \"Darwin\" or python_version >= \"3.3\" and sys_platform == \"darwin\""
 name = "appnope"
 optional = false
 python-versions = "*"
@@ -78,7 +78,6 @@ tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.i
 [[package]]
 category = "main"
 description = "Specifications for callback functions passed in to an API"
-marker = "python_version >= \"3.3\""
 name = "backcall"
 optional = false
 python-versions = "*"
@@ -560,7 +559,6 @@ test = ["pytest (>=3.6.0)", "pytest-cov", "mock"]
 [[package]]
 category = "main"
 description = "An autocompletion tool for Python that can be used for text editors."
-marker = "python_version >= \"3.3\""
 name = "jedi"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -1054,7 +1052,7 @@ six = "*"
 [[package]]
 category = "main"
 description = "Pexpect allows easy control of interactive console applications."
-marker = "python_version >= \"3.3\" and sys_platform != \"win32\""
+marker = "python_version >= \"3.3\" and sys_platform != \"win32\" or sys_platform != \"win32\""
 name = "pexpect"
 optional = false
 python-versions = "*"
@@ -1066,7 +1064,6 @@ ptyprocess = ">=0.5"
 [[package]]
 category = "main"
 description = "Tiny 'shelve'-like database with concurrency support"
-marker = "python_version >= \"3.3\""
 name = "pickleshare"
 optional = false
 python-versions = "*"
@@ -1517,6 +1514,14 @@ version = "1.5.0"
 
 [[package]]
 category = "main"
+description = "Simple, fast, extensible JSON encoder/decoder for Python"
+name = "simplejson"
+optional = false
+python-versions = ">=2.5, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "3.17.2"
+
+[[package]]
+category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
@@ -1759,7 +1764,7 @@ pymc3 = ["pymc3", "jupyter", "seaborn"]
 pyro = ["pyro-ppl", "jupyter", "seaborn"]
 
 [metadata]
-content-hash = "343e5b1d19cb599aa578ddd1ca9864bec7f4f4c7b0c2b0751ce6f9c6f5154aa8"
+content-hash = "94cf6e44e53950f0d57c45f20deba26f6fd8eb1ba3304878feb95f691c00c888"
 lock-version = "1.0"
 python-versions = ">=3.6.8"
 
@@ -2089,19 +2094,16 @@ kiwisolver = [
     {file = "kiwisolver-1.2.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:443c2320520eda0a5b930b2725b26f6175ca4453c61f739fef7a5847bd262f74"},
     {file = "kiwisolver-1.2.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:efcf3397ae1e3c3a4a0a0636542bcad5adad3b1dd3e8e629d0b6e201347176c8"},
     {file = "kiwisolver-1.2.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fccefc0d36a38c57b7bd233a9b485e2f1eb71903ca7ad7adacad6c28a56d62d2"},
-    {file = "kiwisolver-1.2.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:be046da49fbc3aa9491cc7296db7e8d27bcf0c3d5d1a40259c10471b014e4e0c"},
     {file = "kiwisolver-1.2.0-cp36-none-win32.whl", hash = "sha256:60a78858580761fe611d22127868f3dc9f98871e6fdf0a15cc4203ed9ba6179b"},
     {file = "kiwisolver-1.2.0-cp36-none-win_amd64.whl", hash = "sha256:556da0a5f60f6486ec4969abbc1dd83cf9b5c2deadc8288508e55c0f5f87d29c"},
     {file = "kiwisolver-1.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7cc095a4661bdd8a5742aaf7c10ea9fac142d76ff1770a0f84394038126d8fc7"},
     {file = "kiwisolver-1.2.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c955791d80e464da3b471ab41eb65cf5a40c15ce9b001fdc5bbc241170de58ec"},
     {file = "kiwisolver-1.2.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:603162139684ee56bcd57acc74035fceed7dd8d732f38c0959c8bd157f913fec"},
-    {file = "kiwisolver-1.2.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:63f55f490b958b6299e4e5bdac66ac988c3d11b7fafa522800359075d4fa56d1"},
     {file = "kiwisolver-1.2.0-cp37-none-win32.whl", hash = "sha256:03662cbd3e6729f341a97dd2690b271e51a67a68322affab12a5b011344b973c"},
     {file = "kiwisolver-1.2.0-cp37-none-win_amd64.whl", hash = "sha256:4eadb361baf3069f278b055e3bb53fa189cea2fd02cb2c353b7a99ebb4477ef1"},
     {file = "kiwisolver-1.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c31bc3c8e903d60a1ea31a754c72559398d91b5929fcb329b1c3a3d3f6e72113"},
     {file = "kiwisolver-1.2.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:d52b989dc23cdaa92582ceb4af8d5bcc94d74b2c3e64cd6785558ec6a879793e"},
     {file = "kiwisolver-1.2.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:e586b28354d7b6584d8973656a7954b1c69c93f708c0c07b77884f91640b7657"},
-    {file = "kiwisolver-1.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:38d05c9ecb24eee1246391820ed7137ac42a50209c203c908154782fced90e44"},
     {file = "kiwisolver-1.2.0-cp38-none-win32.whl", hash = "sha256:d069ef4b20b1e6b19f790d00097a5d5d2c50871b66d10075dab78938dc2ee2cf"},
     {file = "kiwisolver-1.2.0-cp38-none-win_amd64.whl", hash = "sha256:18d749f3e56c0480dccd1714230da0f328e6e4accf188dd4e6884bdd06bf02dd"},
     {file = "kiwisolver-1.2.0.tar.gz", hash = "sha256:247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f"},
@@ -2609,6 +2611,53 @@ seaborn = [
 send2trash = [
     {file = "Send2Trash-1.5.0-py3-none-any.whl", hash = "sha256:f1691922577b6fa12821234aeb57599d887c4900b9ca537948d2dac34aea888b"},
     {file = "Send2Trash-1.5.0.tar.gz", hash = "sha256:60001cc07d707fe247c94f74ca6ac0d3255aabcb930529690897ca2a39db28b2"},
+]
+simplejson = [
+    {file = "simplejson-3.17.2-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:2d3eab2c3fe52007d703a26f71cf649a8c771fcdd949a3ae73041ba6797cfcf8"},
+    {file = "simplejson-3.17.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:813846738277729d7db71b82176204abc7fdae2f566e2d9fcf874f9b6472e3e6"},
+    {file = "simplejson-3.17.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:292c2e3f53be314cc59853bd20a35bf1f965f3bc121e007ab6fd526ed412a85d"},
+    {file = "simplejson-3.17.2-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:0dd9d9c738cb008bfc0862c9b8fa6743495c03a0ed543884bf92fb7d30f8d043"},
+    {file = "simplejson-3.17.2-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:42b8b8dd0799f78e067e2aaae97e60d58a8f63582939af60abce4c48631a0aa4"},
+    {file = "simplejson-3.17.2-cp27-cp27m-win32.whl", hash = "sha256:8042040af86a494a23c189b5aa0ea9433769cc029707833f261a79c98e3375f9"},
+    {file = "simplejson-3.17.2-cp27-cp27m-win_amd64.whl", hash = "sha256:034550078a11664d77bc1a8364c90bb7eef0e44c2dbb1fd0a4d92e3997088667"},
+    {file = "simplejson-3.17.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:fed0f22bf1313ff79c7fc318f7199d6c2f96d4de3234b2f12a1eab350e597c06"},
+    {file = "simplejson-3.17.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:2e7b57c2c146f8e4dadf84977a83f7ee50da17c8861fd7faf694d55e3274784f"},
+    {file = "simplejson-3.17.2-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:da3c55cdc66cfc3fffb607db49a42448785ea2732f055ac1549b69dcb392663b"},
+    {file = "simplejson-3.17.2-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:c1cb29b1fced01f97e6d5631c3edc2dadb424d1f4421dad079cb13fc97acb42f"},
+    {file = "simplejson-3.17.2-cp33-cp33m-win32.whl", hash = "sha256:8f713ea65958ef40049b6c45c40c206ab363db9591ff5a49d89b448933fa5746"},
+    {file = "simplejson-3.17.2-cp33-cp33m-win_amd64.whl", hash = "sha256:344e2d920a7f27b4023c087ab539877a1e39ce8e3e90b867e0bfa97829824748"},
+    {file = "simplejson-3.17.2-cp34-cp34m-win32.whl", hash = "sha256:05b43d568300c1cd43f95ff4bfcff984bc658aa001be91efb3bb21df9d6288d3"},
+    {file = "simplejson-3.17.2-cp34-cp34m-win_amd64.whl", hash = "sha256:cff6453e25204d3369c47b97dd34783ca820611bd334779d22192da23784194b"},
+    {file = "simplejson-3.17.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:8acf76443cfb5c949b6e781c154278c059b09ac717d2757a830c869ba000cf8d"},
+    {file = "simplejson-3.17.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:869a183c8e44bc03be1b2bbcc9ec4338e37fa8557fc506bf6115887c1d3bb956"},
+    {file = "simplejson-3.17.2-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:5c659a0efc80aaaba57fcd878855c8534ecb655a28ac8508885c50648e6e659d"},
+    {file = "simplejson-3.17.2-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:72d8a3ffca19a901002d6b068cf746be85747571c6a7ba12cbcf427bfb4ed971"},
+    {file = "simplejson-3.17.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:4b3442249d5e3893b90cb9f72c7d6ce4d2ea144d2c0d9f75b9ae1e5460f3121a"},
+    {file = "simplejson-3.17.2-cp35-cp35m-win32.whl", hash = "sha256:e058c7656c44fb494a11443191e381355388443d543f6fc1a245d5d238544396"},
+    {file = "simplejson-3.17.2-cp35-cp35m-win_amd64.whl", hash = "sha256:934115642c8ba9659b402c8bdbdedb48651fb94b576e3b3efd1ccb079609b04a"},
+    {file = "simplejson-3.17.2-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:ffd4e4877a78c84d693e491b223385e0271278f5f4e1476a4962dca6824ecfeb"},
+    {file = "simplejson-3.17.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:10fc250c3edea4abc15d930d77274ddb8df4803453dde7ad50c2f5565a18a4bb"},
+    {file = "simplejson-3.17.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:76ac9605bf2f6d9b56abf6f9da9047a8782574ad3531c82eae774947ae99cc3f"},
+    {file = "simplejson-3.17.2-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:7f10f8ba9c1b1430addc7dd385fc322e221559d3ae49b812aebf57470ce8de45"},
+    {file = "simplejson-3.17.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:bc00d1210567a4cdd215ac6e17dc00cb9893ee521cee701adfd0fa43f7c73139"},
+    {file = "simplejson-3.17.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:af4868da7dd53296cd7630687161d53a7ebe2e63814234631445697bd7c29f46"},
+    {file = "simplejson-3.17.2-cp36-cp36m-win32.whl", hash = "sha256:7d276f69bfc8c7ba6c717ba8deaf28f9d3c8450ff0aa8713f5a3280e232be16b"},
+    {file = "simplejson-3.17.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a55c76254d7cf8d4494bc508e7abb993a82a192d0db4552421e5139235604625"},
+    {file = "simplejson-3.17.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:9a2b7543559f8a1c9ed72724b549d8cc3515da7daf3e79813a15bdc4a769de25"},
+    {file = "simplejson-3.17.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:311f5dc2af07361725033b13cc3d0351de3da8bede3397d45650784c3f21fbcf"},
+    {file = "simplejson-3.17.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2862beabfb9097a745a961426fe7daf66e1714151da8bb9a0c430dde3d59c7c0"},
+    {file = "simplejson-3.17.2-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:afebfc3dd3520d37056f641969ce320b071bc7a0800639c71877b90d053e087f"},
+    {file = "simplejson-3.17.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:d4813b30cb62d3b63ccc60dd12f2121780c7a3068db692daeb90f989877aaf04"},
+    {file = "simplejson-3.17.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3fabde09af43e0cbdee407555383063f8b45bfb52c361bc5da83fcffdb4fd278"},
+    {file = "simplejson-3.17.2-cp37-cp37m-win32.whl", hash = "sha256:ceaa28a5bce8a46a130cd223e895080e258a88d51bf6e8de2fc54a6ef7e38c34"},
+    {file = "simplejson-3.17.2-cp37-cp37m-win_amd64.whl", hash = "sha256:9551f23e09300a9a528f7af20e35c9f79686d46d646152a0c8fc41d2d074d9b0"},
+    {file = "simplejson-3.17.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:c94dc64b1a389a416fc4218cd4799aa3756f25940cae33530a4f7f2f54f166da"},
+    {file = "simplejson-3.17.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b59aa298137ca74a744c1e6e22cfc0bf9dca3a2f41f51bc92eb05695155d905a"},
+    {file = "simplejson-3.17.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ad8f41c2357b73bc9e8606d2fa226233bf4d55d85a8982ecdfd55823a6959995"},
+    {file = "simplejson-3.17.2-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:845a14f6deb124a3bcb98a62def067a67462a000e0508f256f9c18eff5847efc"},
+    {file = "simplejson-3.17.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d0b64409df09edb4c365d95004775c988259efe9be39697d7315c42b7a5e7e94"},
+    {file = "simplejson-3.17.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:55d65f9cc1b733d85ef95ab11f559cce55c7649a2160da2ac7a078534da676c8"},
+    {file = "simplejson-3.17.2.tar.gz", hash = "sha256:75ecc79f26d99222a084fbdd1ce5aad3ac3a8bd535cd9059528452da38b68841"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},

--- a/data-pipeline/pyproject.toml
+++ b/data-pipeline/pyproject.toml
@@ -35,6 +35,7 @@ graphviz = "^0.13.2"
 jupyterlab = "^2.1.1"
 nbdime = "^2.0.0"
 theano = "^1.0.5"
+simplejson = "^3.17.2"
 
 [tool.poetry.extras]
 pymc3 = ["pymc3", "jupyter", "seaborn"]


### PR DESCRIPTION
**Tracking issue:** #531 

* Created [template sheet](https://docs.google.com/spreadsheets/d/1SbnnbflAVYzU4WlBP0iThn-QlYp3AmNbxBW8wc2kgHA/edit#gid=0) to be downloaded as CSV
* Added command `UpdateNPITriggers` to add NPI trigers to a (computed) batch file, creating a batch file with updated definitions (with NPIs added) and truncated timeseries (to contain only valid data).
* Updated WebExport to handle NaNs (although Plotly displays them as 0 .. we would need to remove them in JS, I think)
* See [comment](https://github.com/epidemics/covid/issues/531#issuecomment-694490276) for example commands
* The command and the update loop work, but the [result](http://balochistan.epidemicforecasting.org/?channel=test-t3&scenario=Scenario+1&region=CZ) is buggy.
* I did not manage to hook this machinery into scenario generation, so the exceptions are added on top of existing ones.
  * This seems to be a large source of problems, I am not sure how to proceed.
  * Updating existing exceptions (in the XML) is almost undoable, as they combine different regions (countries, basins, ..) and dates. It is not clear how GLEAM prioritizes.
